### PR TITLE
[INFRA-518] Fix slackSend syntax.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,16 +99,16 @@ pipeline {
 
     post {
         success {
-            slackSend "Success ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)"
+            slackSend(message: "Success ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)")
         }
         unstable {
-            slackSend "Unstable ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)"
+            slackSend(message: "Unstable ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)")
         }
         failure {
-            slackSend "Failure ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)"
+            slackSend(message: "Failure ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)")
         }
         changed {
-            slackSend "Changed ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)"
+            slackSend(message: "Changed ${env.JOB_NAME} ${packageVersion} (<${env.BUILD_URL}|Open>)")
         }
     }
 }


### PR DESCRIPTION
The [recent FMI Jenkins upgrade](https://jira.fmi.fi/browse/INFRA-518) required a fix to Jenkinsfile.