### PR TITLE
[INFRA-518] 'nodejs' to 'node'.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
             steps {
                 sh "env"
                 sh "npm --version"
-                sh "nodejs --version"
+                sh "node --version"
                 sh "rm --recursive --force node_modules"
                 sh "npm install"
             }


### PR DESCRIPTION
The [recent FMI Jenkins upgrade](https://jira.fmi.fi/browse/INFRA-518) required an extra fix to the Jenkinsfile.