### PR TITLE
[SOL-14663] Bump bootstrap-vue from 2.21.2 to 2.22.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@fmidev/smartmet-alert-client",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fmidev/smartmet-alert-client",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "7.12.1",
         "@panzoom/panzoom": "4.4.3",
         "@xmldom/xmldom": "0.7.5",
         "bootstrap": "4.6.1",
-        "bootstrap-vue": "2.21.2",
+        "bootstrap-vue": "2.22.0",
         "cross-fetch": "3.1.5",
         "focus-visible": "5.2.0",
         "he": "1.2.0",
@@ -6311,13 +6311,13 @@
       }
     },
     "node_modules/bootstrap-vue": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.21.2.tgz",
-      "integrity": "sha512-0Exe+4MZysqhZNXIKf4TzkvXaupxh9EHsoCRez0o5Dc0J7rlafayOEwql63qXv74CgZO8E4U8ugRNJko1vMvNw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.22.0.tgz",
+      "integrity": "sha512-denjR/ae0K7Jrcqud3TrZWw0p/crtyigeGUNunWQ4t+KFi+7rzJ6j6lx1W5/gpUtSSUgNbWrXcHH4lIWXzXOOQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@nuxt/opencollective": "^0.3.2",
-        "bootstrap": ">=4.5.3 <5.0.0",
+        "bootstrap": "^4.6.1",
         "popper.js": "^1.16.1",
         "portal-vue": "^2.1.7",
         "vue-functional-data-merge": "^3.1.0"
@@ -33093,12 +33093,12 @@
       "requires": {}
     },
     "bootstrap-vue": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.21.2.tgz",
-      "integrity": "sha512-0Exe+4MZysqhZNXIKf4TzkvXaupxh9EHsoCRez0o5Dc0J7rlafayOEwql63qXv74CgZO8E4U8ugRNJko1vMvNw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.22.0.tgz",
+      "integrity": "sha512-denjR/ae0K7Jrcqud3TrZWw0p/crtyigeGUNunWQ4t+KFi+7rzJ6j6lx1W5/gpUtSSUgNbWrXcHH4lIWXzXOOQ==",
       "requires": {
         "@nuxt/opencollective": "^0.3.2",
-        "bootstrap": ">=4.5.3 <5.0.0",
+        "bootstrap": "^4.6.1",
         "popper.js": "^1.16.1",
         "portal-vue": "^2.1.7",
         "vue-functional-data-merge": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fmidev/smartmet-alert-client",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Web application for viewing weather and flood alerts",
   "author": "Finnish Meteorological Institute",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "@panzoom/panzoom": "4.4.3",
     "@xmldom/xmldom": "0.7.5",
     "bootstrap": "4.6.1",
-    "bootstrap-vue": "2.21.2",
+    "bootstrap-vue": "2.22.0",
     "cross-fetch": "3.1.5",
     "focus-visible": "5.2.0",
     "he": "1.2.0",


### PR DESCRIPTION
Upgrade Bootstrap Vue from 2.21.2 to 2.22.0 to mitigate [SOL-14663](https://jira.fmi.fi/browse/SOL-14663).